### PR TITLE
make validation more robust, adds support for static metadata

### DIFF
--- a/optimus/__main__.py
+++ b/optimus/__main__.py
@@ -32,18 +32,15 @@ def main(args):
         global config
         config = yaml.load(config_file.read())
 
+    # Check that the config has forms and fields properly aligned
     if config.get('redcap_url') and config.get('token'):
         validation.validate_config(config)
+    elif config.get('metadata_path'):
+        with open(config.get('metadata_path'), 'r') as metadata_file:
+            data = json.load(metadata_file)
+        validation.validate_config(config, data)
     else:
-        print("""
-
-        !!!WARNING!!!
-        You are running optimus without a way to connect to RedCap.
-        We CANNOT validate your config, and it could cause data loss.
-
-        If you do not want this, add a redcap_url, and token parameter to the
-        config yaml file.
-        """)
+        validation.warning()
 
 
     csv_file = open(args[_file], 'r')

--- a/optimus/configs/optimus.hcv.conf.yaml
+++ b/optimus/configs/optimus.hcv.conf.yaml
@@ -2,8 +2,10 @@
 
 project: "hcv_target"
 
-redcap_url: http://XXXXXXXXXXX.org/redcap/api/
+redcap_url: http://redi2.dev/redcap/api/
 token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# metadata_path: metadata.json
+
 # redcap form stuff
 
 subject_field: &subject_field dm_subjid

--- a/optimus/configs/optimus.prioritize.conf.yaml
+++ b/optimus/configs/optimus.prioritize.conf.yaml
@@ -4,6 +4,8 @@ project: "prioritize"
 
 redcap_url: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX 
 token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# metadata_path: configs/metadata.json
+
 # redcap form stuff
 
 subject_field: &subject_field dm_subjid

--- a/optimus/validation/validator.py
+++ b/optimus/validation/validator.py
@@ -5,34 +5,78 @@ from itertools import chain
 class Validator(object):
 
     def __init__(self, metadata, form_config):
+        """
+        The metadata should be a deserialized redcap metadata.json response.
+        The form_config is passed in the optimus.conf.yaml that specifies which
+        fields belong to which forms
+        """
         self.form_name = form_config['form_name']
-        self.fields = self._get_fields_from_config(form_config)
-        self.metadata = metadata
+        self.fields = list(self._get_fields_from_config(form_config))
+        self.metadata = [(field['field_name'], field['form_name']) for field in metadata]
 
     def _get_fields_from_config(self, form_config):
+        """
+        We need to check both the fields that we get form the csv directly (csv_fields)
+        as well as the derived fields which come from some operation applied to
+        some of the csv fields.
+        """
         csv_fields = [item for key, item in form_config['csv_fields'].items() if key != 'record_id']
         derived_fields = [item['field'] for key, item in form_config['derived_fields'].items()]
         return list(chain(csv_fields, derived_fields))
 
     def validate(self):
+        """
+        This function makes sure that the fields in the config are both
+        in the metadata and that the form they are under in the config
+        is the same as the form that they belong to in the redcap.
+        """
         valid = True
-        field_name = None
+        misconfigured_field_name = None
+        names = [name for name, form in self.metadata]
         for my_field in self.fields:
-            for redcap_field in self.metadata:
-                if my_field == redcap_field['field_name']:
-                    valid = valid and self.form_name == redcap_field['form_name']
-            if not valid:
-                field_name = my_field
-                break
-        return valid, field_name, self.form_name
+            if my_field not in names:
+                valid = False
+                misconfigured_field_name = my_field
+        if valid:
+            forms = [form for name, form in self.metadata]
+            for my_field in self.fields:
+                field_form = forms[names.index(my_field)]
+                valid = valid and self.form_name == field_form
+                if not valid:
+                    misconfigured_field_name = my_field
+        return valid, misconfigured_field_name, self.form_name
 
-def validate_config(config, metadata_path=None):
-    if not metadata_path:
+def check_metadata_export_permission(response):
+    """
+    Depending on the redcap version and how it reacts this function
+    may need to be made more robust. Sometimes redcap will happily
+    respond with a 200 status_code but the actual content will be an
+    error
+    """
+    if response.status_code == 403:
+        exit("""
+
+        !!! Optimus validation error !!!
+        You have supplied the wrong URL, token pair in your config,
+        or your token does not have the permission to export metadata.
+
+        Make sure to check your auth information or download the metadata.json
+        and use the metadata_path config to check a local copy of the metadata
+        for validation.
+
+        """)
+
+def validate_config(config, metadata=None):
+    """
+    Instantiates a Validator and uses that with each form config along
+    with the metadata to make sure that the field names in the form are
+    the correct field names.
+    """
+    if not metadata:
         api = API(config['token'], config['redcap_url'], 'v6.16.0.json')
-        metadata = json.loads(str(api.export_metadata().content, 'utf-8'))
-    else:
-        with open(metadata_path, 'r') as infile:
-            metadata = json.loads(infile.read())
+        response = api.export_metadata()
+        check_metadata_export_permission(response)
+        metadata = json.loads(str(response.content, 'utf-8'))
     for form in config['forms']:
         validator = Validator(metadata, form)
         is_valid, field_name, form_name = validator.validate()
@@ -43,5 +87,20 @@ def validate_config(config, metadata_path=None):
             {field_name} does not belong to {form_name} according to the metadata.
             """.format(form_name=form_name, field_name=field_name))
             exit()
+
+def warning():
+    print("""
+
+        !!!WARNING!!!
+        You are running optimus without a way to connect to RedCap.
+        We CANNOT validate your config, and it could cause data loss.
+
+        If you do not want this, add a redcap_url, and token parameter to the
+        config yaml file.
+
+        Alternatively, download the project's metadata in json format and place
+        the path in the config under the 'metadata_path' key
+
+        """)
 
 


### PR DESCRIPTION
Sometimes a optimus run would have a token that is not able to
export metadata. We catch this and inform the user when this happens
now. Additionally one can locally cache the metadata.json to avoid the
call out to redcap.